### PR TITLE
docs: "out" is an invalid flag for apply

### DIFF
--- a/cli/on-boarding/terraform.md
+++ b/cli/on-boarding/terraform.md
@@ -73,5 +73,5 @@ terramate run --parallel 5 -- terraform plan -out plan.tfplan
 ### Apply a Terraform Plan in Changed Stacks
 
 ```bash
-terramate run --changed -- terraform apply -out plan.tfplan -auto-approve
+terramate run --changed -- terraform apply -auto-approve plan.tfplan
 ```


### PR DESCRIPTION
I'm running the docs verbatim (edits for debugging purposes) as a notebook using our [Runme](https://runme.dev/) tool.

I might be wrong but I can't get this to run locally unless I remove the `-out` flag which isn't valid for `terraform apply`.

Here's a Gist of my local session including the last three cells that illustrate the issue: https://gist.github.com/sourishkrout/969b125252d087149d9d08dde2a941fd

Lemme know if I'm missing anything. Thanks!