### PR TITLE
Fix spelling for Profile

### DIFF
--- a/.vitepress/config.ts
+++ b/.vitepress/config.ts
@@ -436,7 +436,7 @@ export default defineConfig({
               ],
             },
             {
-              text: 'Pofile',
+              text: 'Profile',
               collapsed: false,
               items: [
                 // { text: 'Introduction', link: '/cli/introduction' },


### PR DESCRIPTION
The menu item currently says "Pofile" instead of "Profile"