### PR TITLE
fix: vscode file associations for tmgen

### DIFF
--- a/cli/code-generation/tmgen.md
+++ b/cli/code-generation/tmgen.md
@@ -28,8 +28,8 @@ filetype in your [settings](https://code.visualstudio.com/docs/getstarted/settin
 ```json
 {
   "files.associations": {
-    "tf.tmgen": "tf",
-    "json.tmgen": "json",
+    "*.tf.tmgen": "tf",
+    "*.json.tmgen": "json",
     ...
   }
 }


### PR DESCRIPTION
The tmgen files need to be associated with "*." to be picked up by VS Code. 

https://code.visualstudio.com/docs/languages/identifiers 
https://stackoverflow.com/a/36789145