### PR TITLE
correct syntax error in `--disable-safeguards`

### DIFF
--- a/cli/reference/cmdline/run.md
+++ b/cli/reference/cmdline/run.md
@@ -175,7 +175,7 @@ terramate run [options] -- <cmd ...>
 
   Run independent stacks in parallel.
 
-- `--disable-safeguards <types>`, `-`X` A comma-separated list of safeguards.
+- `--disable-safeguards <types>`, `-X` A comma-separated list of safeguards.
 
   This option can be used multiple times.
 


### PR DESCRIPTION
simple fix for a syntax error spotted in docs site