### PR TITLE
fix: another mistake in the terragrunt apply command

### DIFF
--- a/cli/on-boarding/terragrunt.md
+++ b/cli/on-boarding/terragrunt.md
@@ -92,5 +92,5 @@ terramate run --parallel 5 -- terragrunt plan -out plan.tfplan
 ### Apply a Terraform Plan with Terragrunt in Changed Stacks
 
 ```bash
-terramate run --changed -- terragrunt apply plan.tfplan -auto-approve
+terramate run --changed -- terragrunt apply -auto-approve plan.tfplan
 ```


### PR DESCRIPTION
The plan file in the terraform/terragrunt apply command is a positional argument and has to come after all other arguments.