### PR TITLE
FIx debugging globals command

### DIFF
--- a/cli/reference/variables/globals.md
+++ b/cli/reference/variables/globals.md
@@ -120,5 +120,5 @@ configuration is since it is all merged into a single set of globals before eval
 
 ## Debugging Globals
 
-To see all globals available in each stack, the `terramate debug globals` command can be used. For details, please see the
+To see all globals available in each stack, the `terramate debug show globals` command can be used. For details, please see the
 [debug globals](../../reference/cmdline/debug/show/debug-show-globals.md) command.


### PR DESCRIPTION
`terramate debug globals` command said "Error: unexpected argument globals" The right command is `terramate debug show globals`