### PR TITLE
Add missing 'us' option to onboading guides

### DIFF
--- a/cli/getting-started/index.md
+++ b/cli/getting-started/index.md
@@ -415,7 +415,9 @@ Remember the organization's short name that you set for accessing the organizati
 
 Configure your Terramate project to sync data to your Terramate Cloud organization after creating it.
 
-```sh
+::: code-group
+
+```sh [Terramate EU]
 $ cat <<EOF >terramate.tm.hcl
 terramate {
   config {
@@ -429,6 +431,24 @@ EOF
 $ git add terramate.tm.hcl
 $ git commit -m "Add Terramate Cloud configuration"
 ```
+
+```sh{6} [Terramate US]
+$ cat <<EOF >terramate.tm.hcl
+terramate {
+  config {
+    cloud {
+      organization = "organization-short-name" # TODO: fill in your org short name
+      location     = "us"
+    }
+  }
+}
+EOF
+
+$ git add terramate.tm.hcl
+$ git commit -m "Add Terramate Cloud configuration"
+```
+
+:::
 
 ### Create a GitHub repository
 

--- a/cli/on-boarding/opentofu.md
+++ b/cli/on-boarding/opentofu.md
@@ -156,8 +156,9 @@ You can belong to multiple organizations and teams. Click the “join” button 
 
 Configure your Terramate project to sync data to your Terramate Cloud organization after creating it.
 
-```bash
-cat <<EOF >terramate.tm.hcl
+::: code-group
+```sh [Terramate EU]
+$ cat <<EOF >terramate.tm.hcl
 terramate {
   config {
     cloud {
@@ -167,9 +168,26 @@ terramate {
 }
 EOF
 
-git add terramate.tm.hcl
-git commit -m "Add Terramate Cloud configuration"
+$ git add terramate.tm.hcl
+$ git commit -m "Add Terramate Cloud configuration"
 ```
+
+```sh{6} [Terramate US]
+$ cat <<EOF >terramate.tm.hcl
+terramate {
+  config {
+    cloud {
+      organization = "organization-short-name" # TODO: fill in your org short name
+      location     = "us"
+    }
+  }
+}
+EOF
+
+$ git add terramate.tm.hcl
+$ git commit -m "Add Terramate Cloud configuration"
+```
+:::
 
 ## 6: Login from CLI
 

--- a/cli/on-boarding/terraform.md
+++ b/cli/on-boarding/terraform.md
@@ -156,8 +156,9 @@ You can belong to multiple organizations and teams. Click the “join” button 
 
 Configure your Terramate project to sync data to your Terramate Cloud organization after creating it.
 
-```bash
-cat <<EOF >terramate.tm.hcl
+::: code-group
+```sh [Terramate EU]
+$ cat <<EOF >terramate.tm.hcl
 terramate {
   config {
     cloud {
@@ -167,9 +168,26 @@ terramate {
 }
 EOF
 
-git add terramate.tm.hcl
-git commit -m "Add Terramate Cloud configuration"
+$ git add terramate.tm.hcl
+$ git commit -m "Add Terramate Cloud configuration"
 ```
+
+```sh{6} [Terramate US]
+$ cat <<EOF >terramate.tm.hcl
+terramate {
+  config {
+    cloud {
+      organization = "organization-short-name" # TODO: fill in your org short name
+      location     = "us"
+    }
+  }
+}
+EOF
+
+$ git add terramate.tm.hcl
+$ git commit -m "Add Terramate Cloud configuration"
+```
+:::
 
 ## 6: Login from CLI
 

--- a/cli/on-boarding/terragrunt.md
+++ b/cli/on-boarding/terragrunt.md
@@ -154,8 +154,9 @@ You can belong to multiple organizations and teams. Click the “join” button 
 
 Configure your Terramate project to sync data to your Terramate Cloud organization after creating it.
 
-```bash
-cat <<EOF >terramate.tm.hcl
+::: code-group
+```sh [Terramate EU]
+$ cat <<EOF >terramate.tm.hcl
 terramate {
   config {
     cloud {
@@ -165,9 +166,26 @@ terramate {
 }
 EOF
 
-git add terramate.tm.hcl
-git commit -m "Add Terramate Cloud configuration"
+$ git add terramate.tm.hcl
+$ git commit -m "Add Terramate Cloud configuration"
 ```
+
+```sh{6} [Terramate US]
+$ cat <<EOF >terramate.tm.hcl
+terramate {
+  config {
+    cloud {
+      organization = "organization-short-name" # TODO: fill in your org short name
+      location     = "us"
+    }
+  }
+}
+EOF
+
+$ git add terramate.tm.hcl
+$ git commit -m "Add Terramate Cloud configuration"
+```
+:::
 
 ## 9: Login from CLI
 

--- a/cloud/on-boarding/index.md
+++ b/cloud/on-boarding/index.md
@@ -21,15 +21,29 @@ Remember the organization's short name that you set for accessing the organizati
 After creating your organization configure your Terramate Repository to define which Terramate Cloud organization to synchronize data to.
 Create a new file called `terramate.tm.hcl` at the root of your repository and add the following content.
 
-```hcl
+::: code-group
+```hcl [Terramate US]
 terramate {
   config {
     cloud {
       organization = "{organization-short-name}"
+      location     = "us" # set to 'eu' or 'us' depending of if you signed up for cloud.terramate.io or us.cloud.terramate.io
     }
   }
 }
 ```
+
+```hcl [Terramate EU]
+terramate {
+  config {
+    cloud {
+      organization = "{organization-short-name}"
+      location     = "eu" # set to 'eu' or 'us' depending of if you signed up for cloud.terramate.io or us.cloud.terramate.io
+    }
+  }
+}
+```
+:::
 
 ## Login from CLI
 


### PR DESCRIPTION
Adding `us` as a location to all onboarding options https://www.loom.com/share/80b5f561786f4a9e804a5e3804cfa5c4?sid=0e998f3c-ad97-462b-a6fb-8b6aa0e47617