### PR TITLE
add required Terramate version in install action

### DIFF
--- a/cli/automation/github-actions/deployment-workflow.md
+++ b/cli/automation/github-actions/deployment-workflow.md
@@ -59,6 +59,8 @@ jobs:
 
       - name: Install Terramate
         uses: terramate-io/terramate-action@v3
+        with:
+          version: "0.14.0"
 
       - name: Install Terraform
         uses: hashicorp/setup-terraform@v3
@@ -177,6 +179,8 @@ jobs:
 
       - name: Install Terramate
         uses: terramate-io/terramate-action@v3
+        with:
+          version: "0.14.0"
 
       - name: Install OpenTofu
         uses: opentofu/setup-opentofu@v1
@@ -295,6 +299,8 @@ jobs:
 
       - name: Install Terramate
         uses: terramate-io/terramate-action@v3
+        with:
+          version: "0.14.0"
 
       - name: Setup Terragrunt
         uses: autero1/action-terragrunt@v3
@@ -413,6 +419,8 @@ jobs:
 
       - name: Install Terramate
         uses: terramate-io/terramate-action@v3
+        with:
+          version: "0.14.0"
 
       - name: Install Terraform
         uses: hashicorp/setup-terraform@v3
@@ -500,6 +508,8 @@ jobs:
 
       - name: Install Terramate
         uses: terramate-io/terramate-action@v3
+        with:
+          version: "0.14.0"
 
       - name: Install OpenTofu
         uses: opentofu/setup-opentofu@v1
@@ -587,6 +597,8 @@ jobs:
 
       - name: Install Terramate
         uses: terramate-io/terramate-action@v3
+        with:
+          version: "0.14.0"
 
       - name: Setup Terragrunt
         uses: autero1/action-terragrunt@v3

--- a/cli/automation/github-actions/drift-check-workflow.md
+++ b/cli/automation/github-actions/drift-check-workflow.md
@@ -62,6 +62,8 @@ jobs:
 
       - name: Install Terramate
         uses: terramate-io/terramate-action@v3
+        with:
+          version: "0.14.0"
 
       - name: Install Terraform
         uses: hashicorp/setup-terraform@v3
@@ -169,6 +171,8 @@ jobs:
 
       - name: Install Terramate
         uses: terramate-io/terramate-action@v3
+        with:
+          version: "0.14.0"
 
       - name: Install OpenTofu
         uses: opentofu/setup-opentofu@v1
@@ -276,6 +280,8 @@ jobs:
 
       - name: Install Terramate
         uses: terramate-io/terramate-action@v3
+        with:
+          version: "0.14.0"
 
       - name: Setup Terragrunt
         uses: autero1/action-terragrunt@v3

--- a/cli/automation/github-actions/preview-workflow.md
+++ b/cli/automation/github-actions/preview-workflow.md
@@ -60,6 +60,8 @@ jobs:
 
       - name: Install Terramate
         uses: terramate-io/terramate-action@v3
+        with:
+          version: "0.14.0"
 
       - name: Install Terraform
         uses: hashicorp/setup-terraform@v3
@@ -167,6 +169,8 @@ jobs:
 
       - name: Install Terramate
         uses: terramate-io/terramate-action@v3
+        with:
+          version: "0.14.0"
 
       - name: Install OpenTofu
         uses: opentofu/setup-opentofu@v1
@@ -274,6 +278,8 @@ jobs:
 
       - name: Install Terramate
         uses: terramate-io/terramate-action@v3
+        with:
+          version: "0.14.0"
 
       - name: Setup Terragrunt
         uses: autero1/action-terragrunt@v3
@@ -393,6 +399,8 @@ jobs:
 
       - name: Install Terramate
         uses: terramate-io/terramate-action@v3
+        with:
+          version: "0.14.0"
 
       - name: Install Terraform
         uses: hashicorp/setup-terraform@v3
@@ -559,6 +567,8 @@ jobs:
 
       - name: Install Terramate
         uses: terramate-io/terramate-action@v3
+        with:
+          version: "0.14.0"
 
       - name: Install OpenTofu
         uses: opentofu/setup-opentofu@v1
@@ -725,6 +735,8 @@ jobs:
 
       - name: Install Terramate
         uses: terramate-io/terramate-action@v3
+        with:
+          version: "0.14.0"
 
       - name: Setup Terragrunt
         uses: autero1/action-terragrunt@v3


### PR DESCRIPTION
The `version` attribute is now required in `terramate-action@v3`.