### PR TITLE
docs: add documentation for tm_joinlist and tm_tree functions

### DIFF
--- a/.vitepress/config.ts
+++ b/.vitepress/config.ts
@@ -887,6 +887,10 @@ export default defineConfig({
                       link: '/cli/reference/functions/tm_index',
                     },
                     {
+                      text: 'tm_joinlist',
+                      link: '/cli/reference/functions/tm_joinlist',
+                    },
+                    {
                       text: 'tm_keys',
                       link: '/cli/reference/functions/tm_keys',
                     },
@@ -949,6 +953,10 @@ export default defineConfig({
                     {
                       text: 'tm_transpose',
                       link: '/cli/reference/functions/tm_transpose',
+                    },
+                    {
+                      text: 'tm_tree',
+                      link: '/cli/reference/functions/tm_tree',
                     },
                     {
                       text: 'tm_values',

--- a/cli/reference/functions/tm_joinlist.md
+++ b/cli/reference/functions/tm_joinlist.md
@@ -1,0 +1,204 @@
+---
+title: tm_joinlist | Functions | Configuration Language
+description: |-
+  The tm_joinlist function joins nested lists of strings with a specified
+  separator, converting hierarchical list structures into joined string paths.
+---
+
+# `tm_joinlist` Function
+
+`tm_joinlist` joins nested lists of strings with a specified separator, converting
+hierarchical list structures into joined string paths. It is particularly useful
+for converting the output of `tm_tree` into file paths or other delimited strings.
+
+```hcl
+tm_joinlist(separator, list_of_lists)
+```
+
+The function processes each inner list by joining its elements with the specified
+separator, returning a list of joined strings.
+
+## Arguments
+
+* `separator` - The string to use as a separator when joining list elements. Can be
+  a single character or multi-character string.
+* `list_of_lists` - A list containing lists of strings to be joined. Supports both
+  HCL list and tuple types.
+
+## Return Value
+
+Returns a list of strings, where each string is the result of joining the elements
+of the corresponding inner list with the specified separator.
+
+## Examples
+
+### Basic Path Joining
+
+```hcl
+locals {
+  paths = tm_joinlist("/", [
+    ["root"],
+    ["root", "child"],
+    ["root", "child", "leaf"]
+  ])
+  # Returns: ["root", "root/child", "root/child/leaf"]
+}
+```
+
+### Different Separators
+
+```hcl
+locals {
+  # Using dot notation
+  namespaces = tm_joinlist(".", [
+    ["com"],
+    ["com", "example"],
+    ["com", "example", "app"]
+  ])
+  # Returns: ["com", "com.example", "com.example.app"]
+  
+  # Using double colon
+  cpp_namespaces = tm_joinlist("::", [
+    ["std"],
+    ["std", "vector"],
+    ["std", "map"]
+  ])
+  # Returns: ["std", "std::vector", "std::map"]
+}
+```
+
+### Integration with tm_tree
+
+```hcl
+locals {
+  # Define hierarchical structure
+  tree_pairs = [
+    [null, "src"],
+    ["src", "main"],
+    ["src", "test"],
+    ["main", "java"],
+    ["main", "resources"],
+    ["test", "java"],
+    ["test", "resources"]
+  ]
+  
+  # Convert to tree branches
+  tree_branches = tm_tree(local.tree_pairs)
+  
+  # Join into paths
+  directory_paths = tm_joinlist("/", local.tree_branches)
+  # Returns: [
+  #   "src",
+  #   "src/main",
+  #   "src/main/java",
+  #   "src/main/resources",
+  #   "src/test",
+  #   "src/test/java",
+  #   "src/test/resources"
+  # ]
+}
+```
+
+## Common Use Cases
+
+### File Path Generation
+
+```hcl
+locals {
+  module_structure = [
+    ["terraform"],
+    ["terraform", "modules"],
+    ["terraform", "modules", "network"],
+    ["terraform", "modules", "compute"],
+    ["terraform", "environments"],
+    ["terraform", "environments", "dev"],
+    ["terraform", "environments", "prod"]
+  ]
+  
+  file_paths = tm_joinlist("/", local.module_structure)
+  
+  # Create .tf files in each directory
+  module_files = [
+    for path in local.file_paths : "${path}/main.tf"
+  ]
+}
+```
+
+### Package Naming
+
+```hcl
+locals {
+  package_hierarchy = [
+    ["com"],
+    ["com", "company"],
+    ["com", "company", "product"],
+    ["com", "company", "product", "service"],
+    ["com", "company", "product", "model"],
+    ["com", "company", "product", "controller"]
+  ]
+  
+  java_packages = tm_joinlist(".", local.package_hierarchy)
+  # Returns Java package names like "com.company.product.service"
+}
+```
+
+### AWS Resource Naming
+
+```hcl
+locals {
+  resource_hierarchy = [
+    ["prod"],
+    ["prod", "us-east-1"],
+    ["prod", "us-east-1", "vpc"],
+    ["prod", "us-east-1", "vpc", "public"],
+    ["prod", "us-east-1", "vpc", "private"]
+  ]
+  
+  resource_names = tm_joinlist("-", local.resource_hierarchy)
+  # Returns: [
+  #   "prod",
+  #   "prod-us-east-1",
+  #   "prod-us-east-1-vpc",
+  #   "prod-us-east-1-vpc-public",
+  #   "prod-us-east-1-vpc-private"
+  # ]
+}
+```
+
+### URL Path Construction
+
+```hcl
+locals {
+  api_paths = [
+    ["api"],
+    ["api", "v1"],
+    ["api", "v1", "users"],
+    ["api", "v1", "users", "{id}"],
+    ["api", "v1", "products"],
+    ["api", "v1", "products", "{id}"]
+  ]
+  
+  endpoints = tm_joinlist("/", local.api_paths)
+  
+  # Prepend with base URL
+  full_urls = [
+    for endpoint in local.endpoints : "https://api.example.com/${endpoint}"
+  ]
+}
+```
+
+## Error Handling
+
+The function validates inputs and provides comprehensive error handling for:
+
+* Invalid separator types (must be a string)
+* Invalid list structure (must be a list of lists)
+* Non-string elements in inner lists
+
+## Related Functions
+
+* [`tm_tree`](./tm_tree.md) - Generates hierarchical list structures that can be
+  joined using `tm_joinlist`
+* [`tm_join`](./tm_join.md) - Joins elements of a single list with a separator
+* [`tm_split`](./tm_split.md) - Performs the opposite operation, splitting strings
+  into lists

--- a/cli/reference/functions/tm_tree.md
+++ b/cli/reference/functions/tm_tree.md
@@ -1,0 +1,142 @@
+---
+title: tm_tree | Functions | Configuration Language
+description: |-
+  The tm_tree function converts an unordered list of parent-child pairs into
+  hierarchical paths, supporting multiple root structures.
+---
+
+# `tm_tree` Function
+
+`tm_tree` converts an unordered list of parent-child pairs into hierarchical paths.
+It takes a list of `[parent, child]` tuples and returns a list of paths, where each
+path is a list of strings from root to node.
+
+```hcl
+tm_tree(pairs)
+```
+
+The function processes parent-child relationships to build tree structures, where:
+- A `null` parent indicates a root node
+- Each path represents a complete branch from root to node
+- Output is deterministically sorted in lexicographical order
+
+## Arguments
+
+* `pairs` - A list of tuples, where each tuple contains `[parent, child]`. The parent
+  can be `null` to indicate a root node.
+
+## Return Value
+
+Returns a list of paths, where each path is a list of strings representing the 
+hierarchical path from root to node.
+
+## Examples
+
+### Basic Tree Structure
+
+```hcl
+locals {
+  pairs = [
+    [null, "root"],
+    ["root", "child1"],
+    ["root", "child2"],
+    ["child1", "grandchild"]
+  ]
+  branches = tm_tree(local.pairs)
+  # Returns: [
+  #   ["root"],
+  #   ["root", "child1"],
+  #   ["root", "child1", "grandchild"],
+  #   ["root", "child2"]
+  # ]
+}
+```
+
+### Multiple Root Nodes
+
+```hcl
+locals {
+  pairs = [
+    [null, "root1"],
+    [null, "root2"],
+    ["root1", "branch1"],
+    ["root2", "branch2"]
+  ]
+  branches = tm_tree(local.pairs)
+  # Returns: [
+  #   ["root1"],
+  #   ["root1", "branch1"],
+  #   ["root2"],
+  #   ["root2", "branch2"]
+  # ]
+}
+```
+
+### Complex Hierarchies
+
+```hcl
+locals {
+  org_structure = [
+    [null, "company"],
+    ["company", "engineering"],
+    ["company", "sales"],
+    ["engineering", "backend"],
+    ["engineering", "frontend"],
+    ["backend", "api"],
+    ["backend", "database"],
+    ["frontend", "web"],
+    ["frontend", "mobile"]
+  ]
+  org_tree = tm_tree(local.org_structure)
+  # Returns hierarchical paths for the entire organization structure
+}
+```
+
+## Error Handling
+
+The function validates the tree structure and will report errors for:
+
+* **Cycles**: When a node is its own ancestor
+* **Conflicting Parents**: When a child has multiple different parents
+* **Unknown Parents**: When a parent reference doesn't exist in the tree
+
+## Common Use Cases
+
+### Directory Structure Generation
+
+```hcl
+locals {
+  module_hierarchy = [
+    [null, "modules"],
+    ["modules", "networking"],
+    ["modules", "compute"],
+    ["networking", "vpc"],
+    ["networking", "firewall"],
+    ["compute", "instances"],
+    ["compute", "loadbalancer"]
+  ]
+  module_paths = tm_tree(local.module_hierarchy)
+  # Use with tm_joinlist to create file paths
+  file_paths = tm_joinlist("/", local.module_paths)
+}
+```
+
+### Dependency Management
+
+```hcl
+locals {
+  dependencies = [
+    [null, "base"],
+    ["base", "network"],
+    ["network", "compute"],
+    ["compute", "application"]
+  ]
+  deployment_order = tm_tree(local.dependencies)
+  # Returns deployment order respecting dependencies
+}
+```
+
+## Related Functions
+
+* [`tm_joinlist`](./tm_joinlist.md) - Joins the hierarchical paths produced by `tm_tree`
+  into string paths with a specified separator


### PR DESCRIPTION
 Summary

  - Adds comprehensive documentation for the new tm_joinlist function that joins nested lists with separators
  - Adds comprehensive documentation for the new tm_tree function that builds hierarchical structures from parent-child pairs
  - Updates navigation configuration to include links to the new function documentation

  Details

  This PR introduces documentation for two complementary Terramate functions that enable sophisticated hierarchical data processing:

  tm_joinlist Function

  - Joins nested lists of strings with a specified separator
  - Particularly useful for converting tree structures into file paths
  - Supports various separators for different use cases (paths, namespaces, resource names)
  - Includes examples for file paths, Java packages, AWS resources, and URL construction

  tm_tree Function

  - Converts unordered parent-child pairs into hierarchical path structures
  - Supports multiple root nodes and complex tree hierarchies
  - Validates tree structure and reports cycles, conflicts, and unknown parents
  - Designed to work seamlessly with tm_joinlist for path generation

  Test Plan

  - Documentation builds without errors
  - Links in navigation menu work correctly
  - Code examples in documentation are syntactically correct
  - Cross-references between tm_joinlist and tm_tree pages work
