### PR TITLE
chore: update codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,4 @@
 * @soerenmartius @mariux
+/.vitepress @terramate-io/tmc-frontend @terramate-io/tmc-backend @soerenmartius @mariux
 /cli @terramate-io/cli-tooling @soerenmartius @mariux
-/cloud @terramate-io/tmc-frontend @terramate-io/tmc-backend @soerenmartius@mariux
+/cloud @terramate-io/tmc-frontend @terramate-io/tmc-backend @soerenmartius @mariux


### PR DESCRIPTION
# Summary

Updates CODEOWNERS to expand approval permissions for Vitepress documentation configuration changes beyond just Marius and Soren.

## Changes

- Added @terramate-io/tmc-frontend and @terramate-io/tmc-backend teams as codeowners for /.vitepress directory
- Maintains existing ownership structure for /cli and /cloud directories
- Keeps Marius and Soren as codeowners alongside the new teams

## Motivation

Currently, only Marius and Soren can approve changes to the documentation site configuration. This creates a bottleneck when team members need to add new links or make configuration changes to the docs site. By adding the frontend and backend teams as additional codeowners for the Vitepress configuration, we enable more team members to review and approve these changes while maintaining appropriate oversight.

## Testing

- Verified CODEOWNERS syntax is valid
- Confirmed the specified teams exist in the GitHub organization

## Type of Change

  - Configuration change
