### PR TITLE
docs: add terramate.stack.parent.tags to metadata

### DIFF
--- a/cli/reference/variables/metadata.md
+++ b/cli/reference/variables/metadata.md
@@ -33,6 +33,7 @@ The following keys are available in the `terramate.stack` object and can be acce
     - `to_root` (string) The relative path from the stack to the repository root (upwards).
   - `parent` (object): An object defining metadata for the immediate parent stack (if it exists):
     - `id` (string): The unique ID of the immediate parent stack.
+    - `tags` (list of string) The user-defined `tags` of the immediate parent stack.
 
 ## Repository Metadata
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk documentation-only change; no runtime behavior or APIs are modified.
> 
> **Overview**
> Documents the `tags` field under `terramate.stack.parent`, clarifying that immediate parent stack metadata now includes user-defined tags alongside the parent `id`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8b078f01222426deb33ed84e75d6432bbf453bbe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->