### PR TITLE
docs: add missing docs for functions from opentofu

### DIFF
--- a/.vitepress/config.ts
+++ b/.vitepress/config.ts
@@ -905,6 +905,10 @@ export default withMermaid(defineConfig({
                       link: '/cli/reference/functions/tm_unslug',
                     },
                     {
+                      text: 'tm_templatestring',
+                      link: '/cli/reference/functions/tm_templatestring',
+                    },
+                    {
                       text: 'tm_upper',
                       link: '/cli/reference/functions/tm_upper',
                     },
@@ -1061,6 +1065,10 @@ export default withMermaid(defineConfig({
                       link: '/cli/reference/functions/tm_base64gzip',
                     },
                     {
+                      text: 'tm_base64gunzip',
+                      link: '/cli/reference/functions/tm_base64gunzip',
+                    },
+                    {
                       text: 'tm_csvdecode',
                       link: '/cli/reference/functions/tm_csvdecode',
                     },
@@ -1095,6 +1103,10 @@ export default withMermaid(defineConfig({
                     {
                       text: 'tm_textencodebase64',
                       link: '/cli/reference/functions/tm_textencodebase64',
+                    },
+                    {
+                      text: 'tm_urldecode',
+                      link: '/cli/reference/functions/tm_urldecode',
                     },
                     {
                       text: 'tm_urlencode',

--- a/cli/reference/functions/tm_base64gunzip.md
+++ b/cli/reference/functions/tm_base64gunzip.md
@@ -1,0 +1,21 @@
+---
+title: tm_base64gunzip | Functions | Configuration Language
+description: |-
+  The tm_base64gunzip function decodes a Base64-encoded string and uncompresses
+  the result with gzip.
+---
+
+# `tm_base64gunzip` Function
+
+`tm_base64gunzip` decodes a Base64-encoded string and uncompresses the result
+with gzip.
+
+Terraform uses the "standard" Base64 alphabet as defined in
+[RFC 4648 section 4](https://tools.ietf.org/html/rfc4648#section-4).
+
+## Related Functions
+
+* [`tm_base64gzip`](./tm_base64gzip.md) compresses a string with gzip and then
+  encodes the result in Base64 encoding.
+* [`tm_base64decode`](./tm_base64decode.md) decodes a Base64 string without
+  gzip decompression.

--- a/cli/reference/functions/tm_base64gzip.md
+++ b/cli/reference/functions/tm_base64gzip.md
@@ -25,6 +25,8 @@ an S3 website.
 
 ## Related Functions
 
+* [`tm_base64gunzip`](./tm_base64gunzip.md) performs the opposite operation,
+  decoding a Base64 string and decompressing the result with gzip.
 * [`tm_base64encode`](./tm_base64encode.md) applies Base64 encoding _without_
   gzip compression.
 * [`tm_filebase64`](./tm_filebase64.md) reads a file from the local filesystem

--- a/cli/reference/functions/tm_templatefile.md
+++ b/cli/reference/functions/tm_templatefile.md
@@ -151,3 +151,5 @@ For more information, see the main documentation for
 
 * [`tm_file`](./tm_file.md) reads a file from disk and returns its literal contents
   without any template interpretation.
+* [`tm_templatestring`](./tm_templatestring.md) takes a string and renders it as
+  a template, without reading from a file.

--- a/cli/reference/functions/tm_templatestring.md
+++ b/cli/reference/functions/tm_templatestring.md
@@ -1,0 +1,71 @@
+---
+title: tm_templatestring | Functions | Configuration Language
+description: |-
+  The tm_templatestring function takes a string and renders it as a template
+  using a supplied set of template variables.
+---
+
+# `tm_templatestring` Function
+
+`tm_templatestring` takes a string and renders it as a template using a
+supplied set of template variables.
+
+```hcl
+tm_templatestring(str, vars)
+```
+
+The template syntax is the same as for
+[string templates](https://developer.hashicorp.com/terraform/language/expressions/strings#string-templates)
+in the main Terramate language, including interpolation sequences delimited with
+`${ ... }`. This function just allows longer template sequences to be factored
+out into a separate string for readability.
+
+When using the `tm_templatestring` function, it's important to keep in mind the
+usage of escape sequences to prevent premature interpolation. To ensure that
+placeholders are treated as literals until they are converted to template
+variables, use the escape sequences `$${...}` and `%%{...}` to represent
+`${...}` and `%{...}` literals, respectively.
+
+The "vars" argument must be an object. Within the template string, each key in
+the map serves as a variable for interpolation. The template may also use any
+other function available in the Terramate language. Variable names must each
+start with a letter, followed by zero or more letters, digits, or underscores.
+
+Strings in the Terramate language are sequences of Unicode characters, so
+this function will interpret the string contents as UTF-8 encoded text.
+Any invalid UTF-8 sequences within the template string will result in an error.
+
+## Examples
+
+### Simple String Template
+
+```sh
+tm_templatestring("Hello, Jodie!", {})
+Hello, Jodie!
+```
+
+### String interpolation with variable
+
+```sh
+tm_templatestring("Hello, $${name}!", { name = "Alice" })
+Hello, Alice!
+```
+
+### Lists
+
+```sh
+tm_templatestring("List Items: $${join(\", \", list)}", { list = ["value1", "value2", "value3"] })
+List Items: value1, value2, value3
+```
+
+### Maps
+
+```sh
+tm_templatestring("%%{ for key, value in map ~}$${key}=$${value} %%{ endfor ~}", { map = { key1 = "value1", key2 = "value2" } })
+key1=value1 key2=value2
+```
+
+## Related Functions
+
+* [`tm_templatefile`](./tm_templatefile.md) reads a file from disk and renders
+  its content as a template using a supplied set of template variables.

--- a/cli/reference/functions/tm_urldecode.md
+++ b/cli/reference/functions/tm_urldecode.md
@@ -1,0 +1,29 @@
+---
+title: tm_urldecode | Functions | Configuration Language
+description: The tm_urldecode function applies URL decoding to a given string.
+---
+
+# `tm_urldecode` Function
+
+`tm_urldecode` applies URL decoding to a given encoded string.
+
+The function is capable of decoding a comprehensive range of characters,
+including those outside the ASCII range. Non-ASCII characters are first treated
+as UTF-8 bytes, followed by the application of percent decoding to each byte,
+facilitating the accurate decoding of multibyte characters.
+
+## Examples
+
+```sh
+tm_urldecode("Hello+World%21")
+Hello World!
+tm_urldecode("%E2%98%83")
+☃
+tm_urldecode("foo%3Abar%40localhost%3Ffoo%3Dbar%26bar%3Dbaz")
+foo:bar@localhost?foo=bar&bar=baz
+```
+
+## Related Functions
+
+* [`tm_urlencode`](./tm_urlencode.md) performs the opposite operation, encoding
+  a string for use in a URL query string.

--- a/cli/reference/functions/tm_urlencode.md
+++ b/cli/reference/functions/tm_urlencode.md
@@ -29,3 +29,8 @@ tm_urlencode("☃")
 tm_urlencode("http://example.com/search?q=${"terraform urlencode"}")
 http://example.com/search?q=terraform+urlencode
 ```
+
+## Related Functions
+
+* [`tm_urldecode`](./tm_urldecode.md) performs the opposite operation, decoding
+  a URL-encoded string.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only changes (new markdown pages and sidebar links) with no runtime or behavior impact.
> 
> **Overview**
> Adds new reference docs for `tm_templatestring`, `tm_base64gunzip`, and `tm_urldecode` and exposes them in the VitePress sidebar under String/Encoding functions.
> 
> Updates existing function pages (`tm_base64gzip`, `tm_templatefile`, `tm_urlencode`) to include *related-function* cross-links to the newly documented counterparts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d1e01f8cdaf647f5464b07266455fa9300c8c36c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->