### PR TITLE
docs: update prompt block docs

### DIFF
--- a/catalyst/reference/variables.md
+++ b/catalyst/reference/variables.md
@@ -22,7 +22,7 @@ terramate.bundles[{class}][{alias}].export
 ### Example usage
 
 ```hcl
-allowed_values = tm_concat(
+options = tm_concat(
   [{ name = "-- None --", value = null }],
   [for parent in tm_try(
     tm_joinlist("/",

--- a/cli/reference/blocks/define-bundle.md
+++ b/cli/reference/blocks/define-bundle.md
@@ -52,19 +52,22 @@ define bundle {
   input "name" {
     type        = string
     description = "Set a name for the service"
-    prompt      = "Name of the Service"
-    required_for_scaffold = true
+    prompt {
+      text = "Name of the Service"
+    }
   }
 
   input "visibility" {
     type        = string
     description = "Visibility of the Resource"
     default     = "private"
-    prompt      = "Visibility"
-    allowed_values = [
-      { name = "A public resource", value = "public" },
-      { name = "A private resource", value = "private" },
-    ]
+    prompt {
+      text    = "Visibility"
+      options = [
+        { name = "A public resource", value = "public" },
+        { name = "A private resource", value = "private" },
+      ]
+    }
   }
 }
 ```
@@ -72,8 +75,8 @@ define bundle {
 ### Notes
 
 - Supported types: `string`, `number`, `any`, `list(...)`, `map(...)`. (Terraform‑style `object` is not supported.)
-- `prompt`, `allowed_values`, `multiselect`, `multiline`, `required_for_scaffold` are used by `terramate scaffold`.
-- `required_for_scaffold` (boolean): include this input in the interactive scaffold flow and require a value.
+- For an input to be shown by `terramate ui`, there needs to be a `prompt` block. It can contain the following attributes:
+  - `text`, `options`, `multiselect`, `multiline`
 
 ## Scaffolding
 
@@ -152,7 +155,7 @@ define bundle export "team_tuple" {
 }
 ```
 
-Exports make precomputed values available to other bundles or code generation (e.g., for `allowed_values`).
+Exports make precomputed values available to other bundles or code generation (e.g., for `options`).
 
 ### Related guides and references
 

--- a/cli/reference/cmdline/scaffold.md
+++ b/cli/reference/cmdline/scaffold.md
@@ -22,7 +22,7 @@ terramate scaffold [--output-format yaml|hcl] [--generate]
 ## Behavior
 
 - Lists Bundles discovered locally (e.g., `/bundles`) and from configured remote catalogs.
-- Prompts for inputs as defined by the bundle (supports `prompt`, `allowed_values`, `multiselect`, `multiline`).
+- Prompts for inputs as defined by the `prompt` sub-block (supports `text`, `options`, `multiselect`, `multiline`).
 - Writes an instantiation file (`bundle.tm.hcl` or `bundle.tm.yml`) based on the bundle’s scaffolding configuration.
 
 ### Related guides and references


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that renames/reshapes the documented scaffold input prompt fields (e.g., `allowed_values` -> `prompt.options`). Risk is limited to confusing users if the documented schema doesn’t match actual CLI behavior.
> 
> **Overview**
> Updates Catalyst/CLI docs to reflect the new `prompt { ... }` input schema, moving prompt text and selectable values under a `prompt` sub-block and renaming `allowed_values` to `prompt.options`.
> 
> Adjusts related references in the `terramate scaffold` and `terramate.bundles` examples/wording to consistently describe exports and UI behavior in terms of `options`/`prompt` blocks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 167b541137da1a39fd2b0124a3dd5a2031f7c11c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->